### PR TITLE
Overlapping text with menu-items fixed

### DIFF
--- a/src/components/Menu/MenuItem/MenuItem.scss
+++ b/src/components/Menu/MenuItem/MenuItem.scss
@@ -2,6 +2,7 @@
     position: fixed;
     top: 50%;
     left: 2em;
+    background-color: var(--bg-primary);
     transform: translateY(-50%);
     visibility: hidden;
     opacity: 0;
@@ -10,6 +11,16 @@
     .menu-item-icon {
         font-size: 2em;
     }
+}
+
+.dark-mode {
+  .menu-item {
+    background-color: var(--bg-primary);
+  }
+    
+  .menu-item:hover {
+    background-color: var(--text-primary);
+  }
 }
 
 .menu-active {

--- a/src/components/Menu/MenuItem/MenuItem.scss
+++ b/src/components/Menu/MenuItem/MenuItem.scss
@@ -13,16 +13,6 @@
     }
 }
 
-.dark-mode {
-  .menu-item {
-    background-color: var(--bg-primary);
-  }
-    
-  .menu-item:hover {
-    background-color: var(--text-primary);
-  }
-}
-
 .menu-active {
     .menu-item {
         visibility: visible;


### PR DESCRIPTION
menu-items were overlapping with the text-behind them. So I have added standard backgrounds to menu-items in both and light mode to make them properly visible and better user experience.